### PR TITLE
Provide Spec to DropTarget

### DIFF
--- a/src/components/FileDrop.js
+++ b/src/components/FileDrop.js
@@ -10,8 +10,10 @@ class FileDrop extends Component {
     }
   }
  
-  handleDroppedFile(props, monitor) {
-    console.log(monitor.getItem().files);
+  dropHandler: {
+    drop(props, monitor) {
+      console.log(monitor.getItem().files);
+    }
   }
  
   render() {
@@ -26,7 +28,7 @@ class FileDrop extends Component {
   }
 }
 
-export default DropTarget(NativeTypes.FILE, FileDrop.handleDroppedFile, (connect, monitor) => ({
+export default DropTarget(NativeTypes.FILE, FileDrop.dropHandler, (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
   isOver: monitor.isOver(),
   canDrop: monitor.canDrop()


### PR DESCRIPTION
spec: Required. A plain JavaScript object with a few allowed methods on it. It describes how the drop target reacts to the drag and drop events. See the drop target specification described in detail in the next section.
